### PR TITLE
add labels and annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ resource "sealedsecrets_secret" "pg_credentials" {
   secrets = {
     key = "value"
   }
+  annotations = {
+    key = "value"
+  }
+  labels = {
+    key = "value"
+  }
 }
 ```
 
@@ -63,7 +69,9 @@ The following arguments are supported:
 - `controller_name` - Name of the SealedSecrets controller in the cluster
 - `controller_namespace` - Namespace of the SealedSecrets controller in the cluster
 - `depends_on` - For specifying hidden dependencies.
-- `secrets` - Key/value pairs to populate the secret
+- `secrets` - Key/value pairs to populate the secret (can be empty, but not really useful here)
+- `annotations` - Key/value pairs to populate the secret (can be empty)
+- `labels` - Key/value pairs to populate the secret (can be empty)
 
 *NOTE: All the arguments above are required*
 

--- a/sealedsecrets/resource_secret.go
+++ b/sealedsecrets/resource_secret.go
@@ -61,6 +61,16 @@ func resourceSecret() *schema.Resource {
 				Computed:    true,
 				Description: "",
 			},
+			"annotations": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Description: "Key/value pairs to populate the secret annotations",
+			},
+			"labels": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Description: "Key/value pairs to populate the secret labels",
+			},
 		},
 	}
 }
@@ -154,7 +164,7 @@ func resourceSecretUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		}
 	}
 
-	if d.HasChange("name") || d.HasChange("secrets") || d.HasChange("type") {
+	if d.HasChange("name") || d.HasChange("secrets") || d.HasChange("type") || d.HasChange("annotations") || d.HasChange("labels") {
 		return resourceSecretCreate(ctx, d, m)
 	}
 
@@ -168,6 +178,8 @@ func createSealedSecret(d *schema.ResourceData, kubeProvider *kubectl.KubeProvid
 	name := d.Get("name").(string)
 	namespace := d.Get("namespace").(string)
 	_type := d.Get("type").(string)
+	annotations := d.Get("annotations").(map[string]interface{})
+	labels := d.Get("labels").(map[string]interface{})
 
 	secretsBase64 := map[string]interface{}{}
 	for key, value := range secrets {
@@ -175,7 +187,7 @@ func createSealedSecret(d *schema.ResourceData, kubeProvider *kubectl.KubeProvid
 		secretsBase64[key] = b64.StdEncoding.EncodeToString([]byte(strValue))
 	}
 
-	secretManifest, err := utils.GenerateSecretManifest(name, namespace, _type, secretsBase64)
+	secretManifest, err := utils.GenerateSecretManifest(name, namespace, _type, secretsBase64, annotations, labels)
 	if err != nil {
 		return "", err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,11 +22,11 @@ metadata:
   namespace: {{ .Namespace }}
   annotations:
     {{- range $key, $value := .Annotations }}
-    {{ $key }}: {{ $value -}}
+    "{{ $key }}": "{{ $value -}}"
     {{ end }}
   labels:
     {{- range $key, $value := .Labels }}
-    {{ $key }}: {{ $value -}}
+    "{{ $key }}": "{{ $value -}}"
     {{ end }}
 type: {{ .Type }}`
 )

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,6 +20,14 @@ metadata:
   creationTimestamp: null
   name: {{ .Name }}
   namespace: {{ .Namespace }}
+  annotations:
+    {{- range $key, $value := .Annotations }}
+    {{ $key }}: {{ $value -}}
+    {{ end }}
+  labels:
+    {{- range $key, $value := .Labels }}
+    {{ $key }}: {{ $value -}}
+    {{ end }}
 type: {{ .Type }}`
 )
 
@@ -28,6 +36,8 @@ type SecretManifest struct {
 	Namespace string
 	Type      string
 	Secrets   map[string]interface{}
+	Annotations   map[string]interface{}
+	Labels   map[string]interface{}
 }
 
 func SHA256(src string) string {
@@ -36,7 +46,7 @@ func SHA256(src string) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func GenerateSecretManifest(name string, namespace string, _type string, secrets map[string]interface{}) (io.Reader, error) {
+func GenerateSecretManifest(name string, namespace string, _type string, secrets map[string]interface{}, annotations map[string]interface{}, labels map[string]interface{}) (io.Reader, error) {
 	secretManifestYAML := new(bytes.Buffer)
 
 	secretManifest := SecretManifest{
@@ -44,6 +54,8 @@ func GenerateSecretManifest(name string, namespace string, _type string, secrets
 		Namespace: namespace,
 		Type:      _type,
 		Secrets:   secrets,
+		Annotations: annotations,
+		Labels: labels,
 	}
 
 	t := template.Must(template.New("secretManifestTemplate").Parse(secretManifestTemplate))


### PR DESCRIPTION
Allow to set labels and annotations on the secrets.
This allows kubed for example to replicate secrets over namespaces.